### PR TITLE
fix: 🐛 site base URL

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,4 @@
-baseURL: "https://codershq.github.io/backend"
+baseURL: "https://coders-hq.github.io/Backend"
 languageCode: "en-us"
 title: "CodersHQ Backend"
 theme: "hugo-geekdoc"


### PR DESCRIPTION
Fix the site base URL to https://coders-hq.github.io/Backend/